### PR TITLE
Laravel 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea
 /vendor/
 composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /vendor/
+.php_cs.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
   "name": "jalameta/jps-support",
   "require": {
-    "illuminate/support" : ">=8.0",
-    "illuminate/database": ">=8.0",
-    "illuminate/http": ">=8.0",
+    "illuminate/support" : ">=5.6",
+    "illuminate/database": ">=5.6",
+    "illuminate/http": ">=5.6",
     "ext-json": "*",
     "nesbot/carbon": "^2.41"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,9 @@
 {
   "name": "jalameta/jps-support",
   "require": {
-    "illuminate/support" : ">=5.6",
-    "illuminate/database": ">=5.6",
-    "illuminate/http": ">=5.6",
-    "ramsey/uuid": ">=3.8",
+    "illuminate/support" : ">=8.0",
+    "illuminate/database": ">=8.0",
+    "illuminate/http": ">=8.0",
     "ext-json": "*",
     "nesbot/carbon": "^2.41"
   },

--- a/src/Database/Eloquent/UuidAsPrimaryKey.php
+++ b/src/Database/Eloquent/UuidAsPrimaryKey.php
@@ -2,10 +2,10 @@
 
 namespace Jalameta\Support\Database\Eloquent;
 
-use Ramsey\Uuid\Uuid;
-use Keiko\Uuid\Shortener\Shortener;
+use Illuminate\Support\Str;
 use Keiko\Uuid\Shortener\Dictionary;
 use Keiko\Uuid\Shortener\Number\BigInt\Converter;
+use Keiko\Uuid\Shortener\Shortener;
 
 /**
  * UUID as primary key in eloquent model.
@@ -39,7 +39,7 @@ trait UuidAsPrimaryKey
      */
     public function generateUuid()
     {
-        $uuid = Uuid::uuid1()->toString();
+        $uuid = Str::orderedUuid();
 
         return ($this->isUsingShortUuid())
             ? $this->uuidShortener()->reduce($uuid)

--- a/src/Database/Eloquent/UuidAsPrimaryKey.php
+++ b/src/Database/Eloquent/UuidAsPrimaryKey.php
@@ -15,6 +15,13 @@ use Keiko\Uuid\Shortener\Number\BigInt\Converter;
 trait UuidAsPrimaryKey
 {
     /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+    
+    /**
      * Generate UUID as primary key upon creating new record on eloquent model.
      *
      * @return void

--- a/src/Database/Eloquent/UuidAsPrimaryKey.php
+++ b/src/Database/Eloquent/UuidAsPrimaryKey.php
@@ -3,9 +3,9 @@
 namespace Jalameta\Support\Database\Eloquent;
 
 use Illuminate\Support\Str;
+use Keiko\Uuid\Shortener\Shortener;
 use Keiko\Uuid\Shortener\Dictionary;
 use Keiko\Uuid\Shortener\Number\BigInt\Converter;
-use Keiko\Uuid\Shortener\Shortener;
 
 /**
  * UUID as primary key in eloquent model.


### PR DESCRIPTION
This merge request was built to update package compatibility to supports to laravel 8. Since I used this package a lot, I want to contribute myself into this package development. Please merge my pull request :smile: 


Update changes
- Laravel 8 support
- Uses Ordered UUID V4 as it is defined in [RFC4122](https://tools.ietf.org/html/rfc4122) for creating more randomness of the generated UUID and still get the `ordered` timestamp feature